### PR TITLE
Use specific major version of react dependency

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,7 @@
     "start": "node node_modules/react-native/local-cli/cli.js start"
   },
   "dependencies": {
-    "react": "^15.3.1",
+    "react": "~15.3.1",
     "react-native": "^0.33.0",
     "react-native-photo-view": "^1.2.0"
   }


### PR DESCRIPTION
React Native 0.33. requires the specific major version 15.3.* of react. Example won't run in current form.